### PR TITLE
Force require-jsdoc on FunctionExpressions within AssignmentExpressions

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ module.exports = {
     'provides-first': require('./provides-first').rule,
     'provides-sorted': require('./provides-sorted').rule,
     'requires-first': require('./requires-first').rule,
+    'require-jsdoc': require('./require-jsdoc').rule,
     'requires-sorted': require('./requires-sorted').rule
   }
 };

--- a/require-jsdoc.js
+++ b/require-jsdoc.js
@@ -8,27 +8,39 @@
  *     // ...
  *   };
  */
-"use strict";
+'use strict';
 
 var original = require('eslint/lib/rules/require-jsdoc');
 
 // just extend the original rule
 var originalCreate = original.create;
 
+/**
+ * Overrides the original rule to always check for JSDoc on FunctionExpressions
+ * within AssignmentExpressions.
+ *
+ * @override
+ */
 original.create = function(context) {
   var rule = originalCreate(context);
   var check = rule.FunctionDeclaration;
   var old = rule.FunctionExpression;
 
+  /**
+   * Overrides the original rule to always check for JSDoc on FunctionExpressions
+   * within AssignmentExpressions.
+   *
+   * @override
+   */
   rule.FunctionExpression = function(node) {
     if (node.parent.type === 'AssignmentExpression') {
       check(node);
     }
 
     old(node);
-  }
+  };
 
   return rule;
-}
+};
 
 exports.rule = original;

--- a/require-jsdoc.js
+++ b/require-jsdoc.js
@@ -1,0 +1,34 @@
+/**
+ * @fileoverview This rule specifically checks for JSDoc on FunctionExpressions
+ *    occurring withing AssignmentExpressions.
+ *
+ * @example
+ *   goog.provide('os.test');
+ *   os.test.doSomething = function(item) { // <-- no docs!
+ *     // ...
+ *   };
+ */
+"use strict";
+
+var original = require('eslint/lib/rules/require-jsdoc');
+
+// just extend the original rule
+var originalCreate = original.create;
+
+original.create = function(context) {
+  var rule = originalCreate(context);
+  var check = rule.FunctionDeclaration;
+  var old = rule.FunctionExpression;
+
+  rule.FunctionExpression = function(node) {
+    if (node.parent.type === 'AssignmentExpression') {
+      check(node);
+    }
+
+    old(node);
+  }
+
+  return rule;
+}
+
+exports.rule = original;

--- a/util.js
+++ b/util.js
@@ -25,22 +25,42 @@ function isGoogStatement(node, name) {
     isGoogCallExpression(node.expression, name);
 }
 
+/**
+ * @param {!AST.Node} node The node
+ * @return {boolean} Whether or not the expression is a goog.provide call
+ */
 exports.isProvideExpression = function(node) {
   return isGoogCallExpression(node, 'provide');
 };
 
+/**
+ * @param {!AST.Node} node The node
+ * @return {boolean} Whether or not the statement is a goog.provide call
+ */
 exports.isProvideStatement = function(node) {
   return isGoogStatement(node, 'provide');
 };
 
+/**
+ * @param {!AST.Node} node The node
+ * @return {boolean} Whether or not the expression is a goog.require call
+ */
 exports.isRequireExpression = function(node) {
   return isGoogCallExpression(node, 'require');
 };
 
+/**
+ * @param {!AST.Node} node The node
+ * @return {boolean} Whether or not the statement is a goog.require call
+ */
 exports.isRequireStatement = function(node) {
   return isGoogStatement(node, 'require');
 };
 
+/**
+ * @param {!AST.Node} node The node
+ * @return {string}
+ */
 var getName = exports.getName = function(node) {
   if (node.type !== 'MemberExpression') {
     return;


### PR DESCRIPTION
The base require-jsdoc rule in eslint (both the version we use and the master branch) does not check AssignmentExpressions. `some.package.thing = function()` is an AssignmentExpression. This extends the base rule and adds checks for those. However, `menuItem.beforeRender = function() {}` is also an assignment, so those will also require docs now.

BREAKING CHANGE: behavior in projects using require-jsdoc will change

Currently the following is not caught:
```
goog.provide('package.test');
package.test.doSomething = function() { // <-- no docs!
};
```
This fixes it.