### PR TITLE
feat(goog): add rules for goog.module and refactor call detection

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,12 +2,14 @@
 
 module.exports = {
   rules: {
+    'modules-first': require('./modules-first').rule,
     'no-duplicate-requires': require('./no-duplicate-requires').rule,
     'no-suppress': require('./no-suppress').rule,
     'provides-first': require('./provides-first').rule,
     'provides-sorted': require('./provides-sorted').rule,
     'requires-first': require('./requires-first').rule,
     'require-jsdoc': require('./require-jsdoc').rule,
-    'requires-sorted': require('./requires-sorted').rule
+    'requires-sorted': require('./requires-sorted').rule,
+    'single-module': require('./single-module').rule
   }
 };

--- a/modules-first.js
+++ b/modules-first.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const util = require('./util');
+
+exports.rule = {
+  meta: {
+    docs: {
+      description: 'require that all goog.module() precede other statements',
+      category: 'Closure Compiler'
+    }
+  },
+
+  create: function(context) {
+    return {
+      Program: function(program) {
+        let otherSeen = false;
+
+        program.body.forEach((statement) => {
+          if (!util.isModuleStatement(statement)) {
+            otherSeen = true;
+          } else if (otherSeen) {
+            return context.report(statement, 'Expected goog.module() to precede other statements');
+          }
+        });
+      }
+    };
+  }
+};

--- a/requires-first.js
+++ b/requires-first.js
@@ -20,7 +20,8 @@ exports.rule = {
             if (otherSeen) {
               return context.report(statement, 'Expected goog.require() to precede other statements');
             }
-          } else if (!util.isProvideStatement(statement) && !util.isModuleStatement(statement)) {
+          } else if (!util.isProvideStatement(statement) && !util.isModuleStatement(statement) &&
+              !util.isLegacyNamespaceStatement(statement)) {
             otherSeen = true;
           }
         });

--- a/requires-sorted.js
+++ b/requires-sorted.js
@@ -41,7 +41,8 @@ exports.rule = {
             }
 
             prevRequire = currRequire;
-          } else if (!util.isProvideStatement(statement)) {
+          } else if (!util.isProvideStatement(statement) && !util.isModuleStatement(statement) &&
+              !util.isLegacyNamespaceStatement(statement)) {
             otherSeen = true;
           }
         });

--- a/single-module.js
+++ b/single-module.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const util = require('./util');
+
+exports.rule = {
+  meta: {
+    docs: {
+      description: 'require that all goog.module() files contain a single module',
+      category: 'Closure Compiler'
+    }
+  },
+
+  create: function(context) {
+    return {
+      Program: function(program) {
+        let moduleSeen = false;
+
+        program.body.forEach((statement) => {
+          if (util.isModuleStatement(statement)) {
+            if (!moduleSeen) {
+              moduleSeen = true;
+            } else {
+              return context.report(statement, 'Expected a single goog.module() statement');
+            }
+          }
+        });
+      }
+    };
+  }
+};


### PR DESCRIPTION
- Added a rule to verify only a single `goog.module` statement appears per file.
- Added a rule to verify the `goog.module` statement is first in the file.
- Allowed `goog.module.declareLegacyNamespace` to precede `goog.require`, so it can be included immediately after the `goog.module` (this is the preferred pattern).
- Replaced specific `goog` call expression functions with a generic `isCallExpression` that can detect a function by any name (ie, `my.namespace.someFn`).