### PR TITLE
fix(eslint): eslint is now a direct dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,9 @@
       "@semantic-release/github"
     ]
   },
+  "dependencies": {
+    "eslint": "^6.0.0"
+  },
   "devDependencies": {
     "@semantic-release/changelog": "^3.0.2",
     "@semantic-release/commit-analyzer": "^6.1.0",
@@ -48,7 +51,6 @@
     "@semantic-release/github": "^5.2.10",
     "@semantic-release/npm": "^5.1.4",
     "@semantic-release/release-notes-generator": "^7.1.4",
-    "eslint": "^6.0.0",
     "eslint-config-google": "0.13.0",
     "husky": "^1.3.1",
     "semantic-release": "^15.13.18",


### PR DESCRIPTION
The `no-unused-var` override uses ESLint utility functions, and is now a direct dependency.