### PR TITLE
feat: detect variable use as a jsdoc type

### DIFF
--- a/rules/no-unused-vars.js
+++ b/rules/no-unused-vars.js
@@ -66,6 +66,7 @@ module.exports = {
 
   create(context) {
     const sourceCode = context.getSourceCode();
+    const comments = sourceCode.getAllComments();
 
     const REST_PROPERTY_TYPE = /^(?:RestElement|(?:Experimental)?RestProperty)$/u;
 
@@ -173,6 +174,25 @@ module.exports = {
 
         return node.parent.type.indexOf('Export') === 0;
       }
+      return false;
+    }
+
+    /**
+     * Determines if a given variable is referenced as a JSDoc type.
+     * @param {Variable} variable eslint-scope variable object.
+     * @return {boolean} True if the variable is used as a JSDoc type, false if not.
+     * @private
+     */
+    function isJsdocType(variable) {
+      const definition = variable.defs[0];
+
+      if (definition) {
+        const pattern = `{[!?]?([^}]*\\|)?${definition.name.name}(\\|[^}]*)?}`;
+        const regexp = new RegExp(pattern);
+
+        return comments.some((comment) => regexp.test(comment.value));
+      }
+
       return false;
     }
 
@@ -618,7 +638,7 @@ module.exports = {
           }
 
           if (!isUsedVariable(variable) && !isExported(variable) && !hasRestSpreadSibling(variable) &&
-              !isGoogRequireType(variable)) {
+              !isGoogRequireType(variable) && !isJsdocType(variable)) {
             unusedVars.push(variable);
           }
         }


### PR DESCRIPTION
The `/* exported variableName */` comment block is ignored when using `sourceType: 'module'`, which will soon be used by OpenSphere.

This updates the `no-unused-vars` rule to check if the variable is a `@typedef` and that it's used as a JSDoc type annotation. The regex pattern looks for the variable inside curly braces, with optional leading `!` or `?` and optional or'ed types before/after the var.