### PR TITLE
feat(es6): allow goog.declareModuleId before goog.require

### DIFF
--- a/rules/requires-first.js
+++ b/rules/requires-first.js
@@ -21,7 +21,7 @@ exports.rule = {
               return context.report(statement, 'Expected goog.require() to precede other statements');
             }
           } else if (!util.isProvideStatement(statement) && !util.isModuleStatement(statement) &&
-              !util.isLegacyNamespaceStatement(statement)) {
+              !util.isLegacyNamespaceStatement(statement) && !util.isDeclareModuleIdStatement(statement)) {
             otherSeen = true;
           }
         });

--- a/rules/util.js
+++ b/rules/util.js
@@ -37,6 +37,14 @@ exports.isModuleStatement = function(node) {
 
 /**
  * @param {!AST.Node} node The node
+ * @return {boolean} Whether or not the statement is a goog.declareModuleId call
+ */
+exports.isDeclareModuleIdStatement = function(node) {
+  return isCallExpression(node, 'goog.declareModuleId');
+};
+
+/**
+ * @param {!AST.Node} node The node
  * @return {boolean} Whether or not the statement is a goog.module.declareLegacyNamespace call
  */
 exports.isLegacyNamespaceStatement = function(node) {


### PR DESCRIPTION
`goog.declareModuleId` is used in ES6 modules to allow using `goog.require` to load the module's exports in a `goog.module`. Allow this statement to appear before `goog.require` statements in a module.